### PR TITLE
Fix 'washed-out' look of 3d terrain map

### DIFF
--- a/src/components/ThreeViewer/Terrain.js
+++ b/src/components/ThreeViewer/Terrain.js
@@ -92,10 +92,12 @@ const TerrainTile = (props) => {
       geometry.setIndex(new THREE.BufferAttribute(indices, 1))
 
       setGeometry(geometry)
+      const map = await mapFuture;
+      map.colorSpace = THREE.SRGBColorSpace;
       setMaterial(
         new THREE.MeshBasicMaterial({
           map: await mapFuture,
-          side: THREE.DoubleSide,
+          side: THREE.FrontSide,
         })
       )
       setMeshLoaded(true)


### PR DESCRIPTION
Different RGB colour spaces are so much fun... :sweat_smile: 

Before:
![Screenshot from 2024-08-19 10-28-49](https://github.com/user-attachments/assets/065f0492-c6a1-4d6f-88af-3b28e691d337)

After:
![Screenshot from 2024-08-19 10-28-31](https://github.com/user-attachments/assets/2da62546-553c-4e2b-ab4d-d83483664b01)
