### PR TITLE
Terrain toggle now only hides terrain tiles instead of destroying them

### DIFF
--- a/src/components/ThreeViewer/Scene.js
+++ b/src/components/ThreeViewer/Scene.js
@@ -79,7 +79,7 @@ const Scene = ({
         setPVPoints={setPVPoints}
       />
 
-      {simulationMesh != undefined && showTerrain && <Terrain />}
+      {simulationMesh != undefined && <Terrain visible={showTerrain}/>}
     </Canvas>
   )
 }

--- a/src/components/ThreeViewer/Terrain.js
+++ b/src/components/ThreeViewer/Terrain.js
@@ -108,7 +108,7 @@ const TerrainTile = (props) => {
   return mesh
 }
 
-const Terrain = () => {
+const Terrain = ({visible}) => {
   const [x, y] = coordinatesXY15
   let tiles = []
   const tx = Math.floor(x * 16)
@@ -127,7 +127,11 @@ const Terrain = () => {
     tiles.push(<TerrainTile key={key} x={tx + dx} y={ty + dy} zoom={19} />)
   }
 
-  return <>{tiles}</>
+  console.log(`Terrain visible:`)
+  console.log(visible);
+  return <group visible={visible}>
+    {tiles}
+  </group>
 }
 
 export default Terrain


### PR DESCRIPTION
Previously, the "hide map"-toggle would destroy all Terrain nodes. This PR makes it so that they are only hidden instead of destroyed, so that they can be toggled back on super quickly. Fixes #169 