### PR TITLE
Add CNAME file during test deployment

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,5 +30,6 @@ jobs:
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/open-pv/website.git
           echo "User-agent: *" > public/robots.txt
           echo "Disallow: /" >> public/robots.txt
+          echo "test.openpv.de" > CNAME
           npm run build
           npm run deploy:test


### PR DESCRIPTION
This adds the CNAME file during test deployment, so that test.openpv.de works again.