### PR TITLE
Generalize select method #291

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -102,7 +102,7 @@
     }
   },
   "savingsCalculation": {
-    "button": "Wirtschaftlichkeit der Anlage berechnen",
+    "button": "Wirtschaftlichkeit berechnen",
     "consumptionTitle": "Jährlicher Stromverbrauch in kWh",
     "consumptionHelperInfo": "Als grober Schätzwert gilt: Rechne pro Person im Haushalt mit 800 kWh, für eine Wärmepumpe 2000 kWh und pro Elektroauto weitere 2000 kWh.",
     "consumptionHelperLabel": "[So berechnen Sie ihren Stromverbrauch]",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -94,12 +94,12 @@
     "leftMouse": "Linke Maustaste: Bewegung auf der Karte",
     "rightMouse": "Rechte Maustaste: Rotation der Karte",
     "wheel": "Mausrad: Vergrößern und Verkleinern",
-    "doubleClick": "Doppelklick: Weiteres Gebäude für Simulation auswählen",
+    "doubleClick": "Doppelklick: Auswählen von Gebäude oder PV-Anlage",
     "touch": {
       "leftMouse": "Ein Finger: Bewegung auf der Karte",
       "rightMouse": "Zwei Finger: Rotation der Karte",
       "wheel": "Zwei Finger: Vergrößern und Verkleinern",
-      "doubleClick": "Zweimal kurz auf Gebäude tippen: Weiteres Gebäude für Simulation auswählen"
+      "doubleClick": "Zweimal kurz tippen: Auswählen von Gebäude oder PV-Anlage"
     }
   },
   "savingsCalculation": {

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -10,6 +10,7 @@
   "next": "Nächste",
   "previous": "Vorherige",
   "close": "Schließen",
+  "delete": "Löschen",
   "searchField": {
     "placeholder": "Geben Sie Ihre Adresse oder Koordinaten ein - z.B. Lange Point 20, Freising"
   },
@@ -102,6 +103,7 @@
     }
   },
   "savingsCalculation": {
+    "notificationLabel": "Für die ausgewählte PV-Anlage:",
     "button": "Wirtschaftlichkeit berechnen",
     "consumptionTitle": "Jährlicher Stromverbrauch in kWh",
     "consumptionHelperInfo": "Als grober Schätzwert gilt: Rechne pro Person im Haushalt mit 800 kWh, für eine Wärmepumpe 2000 kWh und pro Elektroauto weitere 2000 kWh.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -75,12 +75,12 @@
     "leftMouse": "Left Mouse Button: Move on the map",
     "rightMouse": "Right Mouse Button: Rotate the map",
     "wheel": "Mouse Wheel: Zoom in and out",
-    "doubleClick": "Double click: Choose another building for a simulation",
+    "doubleClick": "Double click: Select a builing or PV system",
     "touch": {
       "leftMouse": "One finger: Move on the map",
       "rightMouse": "Two fingers: Rotate the map",
       "wheel": "Two fingers: Zoom in and out",
-      "doubleClick": "Double-tap on a building: Select another building for simulation"
+      "doubleClick": "Double-tap: Select a builing or PV system"
     }
   },
   "savingsCalculation": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -10,6 +10,7 @@
   "next": "Next",
   "previous": "Previous",
   "close": "Close",
+  "delete": "Delete",
   "searchField": {
     "placeholder": "Enter your address or coordinates - e.g. Lange Point 20, Freising"
   },
@@ -83,6 +84,7 @@
     }
   },
   "savingsCalculation": {
+    "notificationLabel": "Continue with chosen pv system:",
     "button": "Calculate Earnings",
     "consumptionTitle": "Annual electricity consumption in kWh",
     "consumptionHelperInfo": "As a rough estimate: Calculate 800 kWh per person in the household, 2000 kWh for a heat pump, and an additional 2000 kWh per electric car.",

--- a/src/components/PVSimulation/SavingsCalculation.jsx
+++ b/src/components/PVSimulation/SavingsCalculation.jsx
@@ -127,6 +127,7 @@ function SavingCalculation({
     <>
       {selectedPVSystem.length > 0 && (
         <Button
+          colorScheme="teal"
           onClick={() => {
             onOpen()
           }}

--- a/src/components/PVSimulation/SavingsCalculation.jsx
+++ b/src/components/PVSimulation/SavingsCalculation.jsx
@@ -21,7 +21,11 @@ import {
 import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 
-function SavingCalculation({ pvSystems }) {
+function SavingCalculation({
+  selectedPVSystem,
+  setSelectedPVSystem,
+  onCloseAlert,
+}) {
   const { isOpen, onOpen, onClose } = useDisclosure({ defaultIsOpen: false })
   const { isOpen: isOpenResultFade, onToggle: onToggleResultFade } =
     useDisclosure({ defaultIsOpen: false })
@@ -32,9 +36,12 @@ function SavingCalculation({ pvSystems }) {
   const [selfConsumption, setSelfConsumption] = useState(0)
   const [annualSavings, setAnnualSavings] = useState(0)
   let pvProduction
-  if (pvSystems.length > 0) {
+  if (selectedPVSystem.length > 0) {
     pvProduction = Math.round(
-      pvSystems.reduce((previous, current) => previous + current.annualYield, 0)
+      selectedPVSystem.reduce(
+        (previous, current) => previous + current.geometry.annualYield,
+        0
+      )
     )
   }
 
@@ -118,12 +125,24 @@ function SavingCalculation({ pvSystems }) {
 
   return (
     <>
-      {pvSystems.length > 0 && (
-        <Button onClick={onOpen} className="button-high-prio">
+      {selectedPVSystem.length > 0 && (
+        <Button
+          onClick={() => {
+            onOpen()
+          }}
+        >
           {t("savingsCalculation.button")}
         </Button>
       )}
-      <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          onClose()
+          onCloseAlert()
+          setSelectedPVSystem([])
+        }}
+        size="xl"
+      >
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>{t("savingsCalculation.button")}</ModalHeader>

--- a/src/components/PVSimulation/SavingsCalculation.jsx
+++ b/src/components/PVSimulation/SavingsCalculation.jsx
@@ -39,7 +39,7 @@ function SavingCalculation({
   if (selectedPVSystem.length > 0) {
     pvProduction = Math.round(
       selectedPVSystem.reduce(
-        (previous, current) => previous + current.geometry.annualYield,
+        (previous, current) => previous + current.annualYield,
         0
       )
     )

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -53,6 +53,9 @@ function CustomMapControl(props) {
     ) {
       props.setSelectedMesh([intersectedMesh])
     }
+    if (intersectedMesh.geometry.name.includes("pvSystem")) {
+      props.setselectedPVSystem([intersectedMesh])
+    }
   }
 
   const handleDoubleClick = (event) => {

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -14,16 +14,20 @@ function CustomMapControl(props) {
   const handleInteraction = (event) => {
     event.preventDefault()
 
-    const isTouch = event.type.startsWith("touch")
-    const clientX = isTouch ? event.touches[0].clientX : event.clientX
-    const clientY = isTouch ? event.touches[0].clientY : event.clientY
+    const getIntersects = () => {
+      const isTouch = window.isTouchDevice
+      const clientX = isTouch ? event.touches[0].clientX : event.clientX
+      const clientY = isTouch ? event.touches[0].clientY : event.clientY
 
-    const rect = event.target.getBoundingClientRect()
-    mouse.current.x = ((clientX - rect.left) / rect.width) * 2 - 1
-    mouse.current.y = (-(clientY - rect.top) / rect.height) * 2 + 1
+      const rect = event.target.getBoundingClientRect()
+      mouse.current.x = ((clientX - rect.left) / rect.width) * 2 - 1
+      mouse.current.y = (-(clientY - rect.top) / rect.height) * 2 + 1
 
-    raycaster.current.setFromCamera(mouse.current, camera)
-    const intersects = raycaster.current.intersectObjects(scene.children, true)
+      raycaster.current.setFromCamera(mouse.current, camera)
+
+      return raycaster.current.intersectObjects(scene.children, true)
+    }
+    const intersects = getIntersects()
 
     if (intersects.length > 0) {
       const intersectedMesh = intersects[0].object

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -58,7 +58,7 @@ function CustomMapControl(props) {
       props.setSelectedMesh([intersectedMesh])
     }
     if (intersectedMesh.geometry.name.includes("pvSystem")) {
-      props.setselectedPVSystem([intersectedMesh])
+      props.setSelectedPVSystem([intersectedMesh])
     }
   }
 

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -37,11 +37,18 @@ function CustomMapControl(props) {
       console.log("No children in the intersected mesh.")
       return
     }
-    let intersectedMesh = intersects[0].object
-    if (intersectedMesh.type === "Sprite") {
-      //ignore Sprites (the label of pvsystems), use the underlying object
-      intersectedMesh = intersects[1].object
+
+    // Filter out Sprites (ie the labels of PV systems)
+    let i = 0
+    while (i < intersects.length && intersects[i].object.type === "Sprite") {
+      i++
     }
+    if (i === intersects.length) {
+      console.log("Only Sprite objects found in intersections.")
+      return
+    }
+
+    let intersectedMesh = intersects[i].object
     console.log("Intersected Mesh", intersectedMesh)
 
     if (!intersectedMesh) return

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -37,7 +37,11 @@ function CustomMapControl(props) {
       console.log("No children in the intersected mesh.")
       return
     }
-    const intersectedMesh = intersects[0].object
+    let intersectedMesh = intersects[0].object
+    if (intersectedMesh.type === "Sprite") {
+      //ignore Sprites (the label of pvsystems), use the underlying object
+      intersectedMesh = intersects[1].object
+    }
     console.log("Intersected Mesh", intersectedMesh)
 
     if (!intersectedMesh) return

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -41,11 +41,15 @@ function CustomMapControl(props) {
     console.log("Intersected Mesh", intersectedMesh)
 
     if (!intersectedMesh) return
-
+    if (!intersectedMesh.geometry.name) {
+      console.log(
+        "There is a mesh, but it has no name so I don't know what to do."
+      )
+      return
+    }
     if (
-      intersectedMesh.geometry.name &&
-      (intersectedMesh.geometry.name.includes("surrounding") ||
-        intersectedMesh.geometry.name.includes("background"))
+      intersectedMesh.geometry.name.includes("surrounding") ||
+      intersectedMesh.geometry.name.includes("background")
     ) {
       props.setSelectedMesh([intersectedMesh])
     }

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -47,24 +47,7 @@ function CustomMapControl(props) {
       (intersectedMesh.geometry.name.includes("surrounding") ||
         intersectedMesh.geometry.name.includes("background"))
     ) {
-      const existingIndex = props.selectedMesh.findIndex(
-        (mesh) => mesh.geometry.name === intersectedMesh.geometry.name
-      )
-
-      if (existingIndex > -1) {
-        props.setSelectedMesh([
-          ...props.selectedMesh.slice(0, existingIndex),
-          ...props.selectedMesh.slice(existingIndex + 1),
-        ])
-      } else {
-        props.setSelectedMesh([
-          ...props.selectedMesh,
-          {
-            geometry: intersectedMesh.geometry,
-            material: intersectedMesh.material,
-          },
-        ])
-      }
+      props.setSelectedMesh([intersectedMesh])
     }
   }
 

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -58,7 +58,7 @@ function CustomMapControl(props) {
       props.setSelectedMesh([intersectedMesh])
     }
     if (intersectedMesh.geometry.name.includes("pvSystem")) {
-      props.setSelectedPVSystem([intersectedMesh])
+      props.setSelectedPVSystem([intersectedMesh.geometry])
     }
   }
 

--- a/src/components/ThreeViewer/Controls/CustomMapControl.jsx
+++ b/src/components/ThreeViewer/Controls/CustomMapControl.jsx
@@ -14,6 +14,10 @@ function CustomMapControl(props) {
   const handleInteraction = (event) => {
     event.preventDefault()
 
+    /**
+     * Returns the list of intersected objects. An intersected object is an object
+     * that lies directly below the mouse cursor.
+     */
     const getIntersects = () => {
       const isTouch = window.isTouchDevice
       const clientX = isTouch ? event.touches[0].clientX : event.clientX
@@ -29,38 +33,38 @@ function CustomMapControl(props) {
     }
     const intersects = getIntersects()
 
-    if (intersects.length > 0) {
-      const intersectedMesh = intersects[0].object
-      console.log("Intersected Mesh", intersectedMesh)
-
-      if (!intersectedMesh) return
-
-      if (
-        intersectedMesh.geometry.name &&
-        (intersectedMesh.geometry.name.includes("surrounding") ||
-          intersectedMesh.geometry.name.includes("background"))
-      ) {
-        const existingIndex = props.selectedMesh.findIndex(
-          (mesh) => mesh.geometry.name === intersectedMesh.geometry.name
-        )
-
-        if (existingIndex > -1) {
-          props.setSelectedMesh([
-            ...props.selectedMesh.slice(0, existingIndex),
-            ...props.selectedMesh.slice(existingIndex + 1),
-          ])
-        } else {
-          props.setSelectedMesh([
-            ...props.selectedMesh,
-            {
-              geometry: intersectedMesh.geometry,
-              material: intersectedMesh.material,
-            },
-          ])
-        }
-      }
-    } else {
+    if (intersects.length === 0) {
       console.log("No children in the intersected mesh.")
+      return
+    }
+    const intersectedMesh = intersects[0].object
+    console.log("Intersected Mesh", intersectedMesh)
+
+    if (!intersectedMesh) return
+
+    if (
+      intersectedMesh.geometry.name &&
+      (intersectedMesh.geometry.name.includes("surrounding") ||
+        intersectedMesh.geometry.name.includes("background"))
+    ) {
+      const existingIndex = props.selectedMesh.findIndex(
+        (mesh) => mesh.geometry.name === intersectedMesh.geometry.name
+      )
+
+      if (existingIndex > -1) {
+        props.setSelectedMesh([
+          ...props.selectedMesh.slice(0, existingIndex),
+          ...props.selectedMesh.slice(existingIndex + 1),
+        ])
+      } else {
+        props.setSelectedMesh([
+          ...props.selectedMesh,
+          {
+            geometry: intersectedMesh.geometry,
+            material: intersectedMesh.material,
+          },
+        ])
+      }
     }
   }
 

--- a/src/components/ThreeViewer/Meshes/HighlitedPVSystem.jsx
+++ b/src/components/ThreeViewer/Meshes/HighlitedPVSystem.jsx
@@ -1,0 +1,21 @@
+import React from "react"
+import * as THREE from "three"
+
+export function HighlightedPVSystem({ meshes }) {
+  return (
+    <>
+      {meshes.map((mesh, index) => (
+        <mesh
+          key={index}
+          geometry={mesh.geometry}
+          material={
+            new THREE.MeshLambertMaterial({
+              color: "red",
+              transparent: false,
+            })
+          }
+        />
+      ))}
+    </>
+  )
+}

--- a/src/components/ThreeViewer/Meshes/HighlitedPVSystem.jsx
+++ b/src/components/ThreeViewer/Meshes/HighlitedPVSystem.jsx
@@ -1,13 +1,13 @@
 import React from "react"
 import * as THREE from "three"
 
-export function HighlightedPVSystem({ meshes }) {
+export function HighlightedPVSystem({ geometries }) {
   return (
     <>
-      {meshes.map((mesh, index) => (
+      {geometries.map((geometry, index) => (
         <mesh
           key={index}
-          geometry={mesh.geometry}
+          geometry={geometry}
           material={
             new THREE.MeshLambertMaterial({
               color: "red",

--- a/src/components/ThreeViewer/Meshes/PVSystems.jsx
+++ b/src/components/ThreeViewer/Meshes/PVSystems.jsx
@@ -73,6 +73,7 @@ export function createPVSystem({
     "position",
     new THREE.Float32BufferAttribute(bufferTriangles, 3)
   )
+  geometry.name = "pvSystem"
 
   let subdividedTriangles = []
   const triangleSubdivisionThreshold = 0.8

--- a/src/components/ThreeViewer/Meshes/PVSystems.jsx
+++ b/src/components/ThreeViewer/Meshes/PVSystems.jsx
@@ -7,13 +7,8 @@ import TextSprite from "../TextSprite"
 export const PVSystems = ({ pvSystems }) => {
   return (
     <>
-      {pvSystems.map((system, index) => (
-        <PVSystem
-          key={index}
-          geometry={system.geometry}
-          annualYield={system.annualYield}
-          area={system.area}
-        />
+      {pvSystems.map((geometry) => (
+        <PVSystem geometry={geometry} />
       ))}
     </>
   )
@@ -140,17 +135,14 @@ export function createPVSystem({
   )
   const annualYield = polygonArea * polygonIntensity
 
-  const newPVSystem = {
-    geometry: geometry,
-    annualYield: annualYield,
-    area: polygonArea,
-  }
+  geometry.annualYield = annualYield
+  geometry.area = polygonArea
 
-  setPVSystems((prevSystems) => [...prevSystems, newPVSystem])
+  setPVSystems((prevSystems) => [...prevSystems, geometry])
   setPVPoints([])
 }
 
-const PVSystem = ({ geometry, annualYield, area }) => {
+const PVSystem = ({ geometry }) => {
   const textRef = useRef()
 
   const center = calculateCenter(geometry.attributes.position.array)
@@ -177,9 +169,9 @@ const PVSystem = ({ geometry, annualYield, area }) => {
       />
 
       <TextSprite
-        text={`Jahresertrag: ${Math.round(annualYield).toLocaleString(
+        text={`Jahresertrag: ${Math.round(geometry.annualYield).toLocaleString(
           "de"
-        )} kWh pro Jahr\nFläche: ${area.toPrecision(3)}m²`}
+        )} kWh pro Jahr\nFläche: ${geometry.area.toPrecision(3)}m²`}
         position={center}
       />
     </>

--- a/src/components/ThreeViewer/Meshes/PVSystems.jsx
+++ b/src/components/ThreeViewer/Meshes/PVSystems.jsx
@@ -141,7 +141,7 @@ export function createPVSystem({
 
   setPVSystems((prevSystems) => [...prevSystems, geometry])
   setPVPoints([])
-  setSelectedPVSystem((prevSystems) => [...prevSystems, geometry])
+  setSelectedPVSystem([geometry])
 }
 
 const PVSystem = ({ geometry }) => {

--- a/src/components/ThreeViewer/Meshes/PVSystems.jsx
+++ b/src/components/ThreeViewer/Meshes/PVSystems.jsx
@@ -16,6 +16,7 @@ export const PVSystems = ({ pvSystems }) => {
 
 export function createPVSystem({
   setPVSystems,
+  setSelectedPVSystem,
   pvPoints,
   setPVPoints,
   simulationMeshes,
@@ -140,6 +141,7 @@ export function createPVSystem({
 
   setPVSystems((prevSystems) => [...prevSystems, geometry])
   setPVPoints([])
+  setSelectedPVSystem((prevSystems) => [...prevSystems, geometry])
 }
 
 const PVSystem = ({ geometry }) => {

--- a/src/components/ThreeViewer/Overlay.jsx
+++ b/src/components/ThreeViewer/Overlay.jsx
@@ -21,13 +21,14 @@ import {
   UnorderedList,
   useDisclosure,
 } from "@chakra-ui/react"
-import React from "react"
+import React, { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { simulationForNewBuilding } from "../../simulation/main"
 import SavingCalculation from "../PVSimulation/SavingsCalculation"
 import ButtonWithHoverHelp from "../Template/ButtonWithHoverHelp"
 import SliderWithLabel from "../Template/SliderWithLabel"
 import { createPVSystem } from "./Meshes/PVSystems"
+import SelectionNotification from "./SelectionNotification"
 
 function Overlay({
   frontendState,
@@ -36,6 +37,8 @@ function Overlay({
   setShowTerrain,
   selectedMesh,
   setSelectedMesh,
+  selectedPVSystem,
+  setSelectedPVSystem,
   geometries,
   geoLocation,
   pvSystems,
@@ -70,10 +73,19 @@ function Overlay({
   const handleAbortButtonClick = () => {
     setFrontendState("Results")
   }
+  const buttons = [
+    { label: "View Account", action: () => console.log("Viewing account") },
+    { label: "Edit Profile", action: () => console.log("Editing profile") },
+  ]
 
   return (
     <>
       <OverlayWrapper>
+        <SelectionNotification
+          selection={selectedPVSystem}
+          setSelection={setSelectedPVSystem}
+          buttons={buttons}
+        />
         {frontendState == "Results" && (
           <>
             <Button

--- a/src/components/ThreeViewer/Overlay.jsx
+++ b/src/components/ThreeViewer/Overlay.jsx
@@ -63,6 +63,7 @@ function Overlay({
   const handleCreatePVButtonClick = () => {
     createPVSystem({
       setPVSystems,
+      setSelectedPVSystem,
       pvPoints,
       setPVPoints,
       simulationMeshes,

--- a/src/components/ThreeViewer/Overlay.jsx
+++ b/src/components/ThreeViewer/Overlay.jsx
@@ -23,11 +23,11 @@ import {
 } from "@chakra-ui/react"
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { simulationForNewBuilding } from "../../simulation/main"
 
 import ButtonWithHoverHelp from "../Template/ButtonWithHoverHelp"
 import SliderWithLabel from "../Template/SliderWithLabel"
 import { createPVSystem } from "./Meshes/PVSystems"
+import SelectionNotificationBuilding from "./SelectionNotificationBuilding"
 import SelectionNotificationPV from "./SelectionNotificationPV"
 
 function Overlay({
@@ -83,6 +83,14 @@ function Overlay({
           setSelectedPVSystem={setSelectedPVSystem}
           setPVSystems={setPVSystems}
         />
+        <SelectionNotificationBuilding
+          selectedMesh={selectedMesh}
+          setSelectedMesh={setSelectedMesh}
+          simulationMeshes={simulationMeshes}
+          setSimulationMeshes={setSimulationMeshes}
+          geometries={geometries}
+          geoLocation={geoLocation}
+        />
         {frontendState == "Results" && (
           <>
             <Button
@@ -128,23 +136,6 @@ function Overlay({
           />
         )}
 
-        {selectedMesh.length > 0 && (
-          <Button
-            className="button-high-prio"
-            onClick={async () =>
-              await simulationForNewBuilding({
-                selectedMesh,
-                setSelectedMesh,
-                simulationMeshes,
-                setSimulationMeshes,
-                geometries,
-                geoLocation,
-              })
-            }
-          >
-            {t("button.simulateBuilding")}
-          </Button>
-        )}
         {frontendState == "DrawPV" && (
           <>
             {pvPoints.length > 0 && (

--- a/src/components/ThreeViewer/Overlay.jsx
+++ b/src/components/ThreeViewer/Overlay.jsx
@@ -21,10 +21,10 @@ import {
   UnorderedList,
   useDisclosure,
 } from "@chakra-ui/react"
-import React, { useEffect, useRef } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
 import { simulationForNewBuilding } from "../../simulation/main"
-import SavingCalculation from "../PVSimulation/SavingsCalculation"
+
 import ButtonWithHoverHelp from "../Template/ButtonWithHoverHelp"
 import SliderWithLabel from "../Template/SliderWithLabel"
 import { createPVSystem } from "./Meshes/PVSystems"

--- a/src/components/ThreeViewer/Overlay.jsx
+++ b/src/components/ThreeViewer/Overlay.jsx
@@ -28,7 +28,7 @@ import SavingCalculation from "../PVSimulation/SavingsCalculation"
 import ButtonWithHoverHelp from "../Template/ButtonWithHoverHelp"
 import SliderWithLabel from "../Template/SliderWithLabel"
 import { createPVSystem } from "./Meshes/PVSystems"
-import SelectionNotification from "./SelectionNotification"
+import SelectionNotificationPV from "./SelectionNotificationPV"
 
 function Overlay({
   frontendState,
@@ -73,18 +73,14 @@ function Overlay({
   const handleAbortButtonClick = () => {
     setFrontendState("Results")
   }
-  const buttons = [
-    { label: "View Account", action: () => console.log("Viewing account") },
-    { label: "Edit Profile", action: () => console.log("Editing profile") },
-  ]
 
   return (
     <>
       <OverlayWrapper>
-        <SelectionNotification
-          selection={selectedPVSystem}
-          setSelection={setSelectedPVSystem}
-          buttons={buttons}
+        <SelectionNotificationPV
+          selectedPVSystem={selectedPVSystem}
+          setSelectedPVSystem={setSelectedPVSystem}
+          setPVSystems={setPVSystems}
         />
         {frontendState == "Results" && (
           <>
@@ -130,7 +126,7 @@ function Overlay({
             hoverText={t("button.drawPVSystemHover")}
           />
         )}
-        <SavingCalculation pvSystems={pvSystems} />
+
         {selectedMesh.length > 0 && (
           <Button
             className="button-high-prio"

--- a/src/components/ThreeViewer/Scene.jsx
+++ b/src/components/ThreeViewer/Scene.jsx
@@ -60,7 +60,9 @@ const Scene = ({
         <SimulationMesh meshes={simulationMeshes} />
       )}
       {selectedMesh && <HighlightedMesh meshes={selectedMesh} />}
-      {selectedPVSystem && <HighlightedPVSystem meshes={selectedPVSystem} />}
+      {selectedPVSystem && (
+        <HighlightedPVSystem geometries={selectedPVSystem} />
+      )}
       {simulationMeshes.length > 0 && frontendState == "Results" && (
         <CustomMapControl
           middle={simulationMeshes[0].middle}

--- a/src/components/ThreeViewer/Scene.jsx
+++ b/src/components/ThreeViewer/Scene.jsx
@@ -21,7 +21,7 @@ const Scene = ({
   selectedMesh,
   setSelectedMesh,
   selectedPVSystem,
-  setselectedPVSystem,
+  setSelectedPVSystem,
   pvPoints,
   setPVPoints,
   vegetationGeometries,
@@ -65,7 +65,7 @@ const Scene = ({
         <CustomMapControl
           middle={simulationMeshes[0].middle}
           setSelectedMesh={setSelectedMesh}
-          setselectedPVSystem={setselectedPVSystem}
+          setSelectedPVSystem={setSelectedPVSystem}
         />
       )}
       {frontendState == "DrawPV" && (

--- a/src/components/ThreeViewer/Scene.jsx
+++ b/src/components/ThreeViewer/Scene.jsx
@@ -1,8 +1,9 @@
-import React, { useRef, useState } from "react"
+import React, { useRef } from "react"
 import { Canvas } from "react-three-fiber"
 
 import CustomMapControl from "./Controls/CustomMapControl"
 import DrawPVControl from "./Controls/DrawPVControl"
+import { HighlightedPVSystem } from "./Meshes/HighlitedPVSystem"
 import { HighlightedMesh } from "./Meshes/HiglightedMesh"
 import { PVSystems } from "./Meshes/PVSystems"
 import SimulationMesh from "./Meshes/SimulationMesh"
@@ -19,6 +20,8 @@ const Scene = ({
   pvSystems,
   selectedMesh,
   setSelectedMesh,
+  selectedPVSystem,
+  setselectedPVSystem,
   pvPoints,
   setPVPoints,
   vegetationGeometries,
@@ -57,11 +60,12 @@ const Scene = ({
         <SimulationMesh meshes={simulationMeshes} />
       )}
       {selectedMesh && <HighlightedMesh meshes={selectedMesh} />}
+      {selectedPVSystem && <HighlightedPVSystem meshes={selectedPVSystem} />}
       {simulationMeshes.length > 0 && frontendState == "Results" && (
         <CustomMapControl
           middle={simulationMeshes[0].middle}
-          selectedMesh={selectedMesh}
           setSelectedMesh={setSelectedMesh}
+          setselectedPVSystem={setselectedPVSystem}
         />
       )}
       {frontendState == "DrawPV" && (

--- a/src/components/ThreeViewer/SelectionNotification.jsx
+++ b/src/components/ThreeViewer/SelectionNotification.jsx
@@ -1,0 +1,78 @@
+import {
+  Alert,
+  AlertDescription,
+  Box,
+  Button,
+  CloseButton,
+  useDisclosure,
+  Wrap,
+  WrapItem,
+} from "@chakra-ui/react"
+import React, { useEffect, useRef } from "react"
+
+const SelectionNotification = ({ selection, setSelection, buttons }) => {
+  const { isOpen, onClose, onOpen } = useDisclosure()
+  const hasShownAlertRef = useRef(false)
+
+  useEffect(() => {
+    if (selection.length > 0 && !hasShownAlertRef.current) {
+      onOpen()
+      hasShownAlertRef.current = true
+    }
+  }, [selection, onOpen])
+
+  const handleCloseAlert = () => {
+    onClose()
+    setSelection([])
+    hasShownAlertRef.current = false
+  }
+
+  const handleButtonClick = (action) => {
+    // Call the button's action if provided
+    if (action) {
+      action()
+    }
+    handleCloseAlert()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <Box
+      position="fixed"
+      bottom={4}
+      left="50%"
+      transform="translateX(-50%)"
+      width="300px"
+      zIndex={9999}
+    >
+      <Alert alignItems="start" boxShadow="md" rounded="md" colorScheme="teal">
+        <Box width="100%">
+          <AlertDescription display="block" mb={2}>
+            We've created your account for you.
+          </AlertDescription>
+          <Wrap spacing={2} justify="start">
+            {buttons.map((button, index) => (
+              <WrapItem key={index}>
+                <Button
+                  size="sm"
+                  onClick={() => handleButtonClick(button.action)}
+                >
+                  {button.label}
+                </Button>
+              </WrapItem>
+            ))}
+          </Wrap>
+        </Box>
+        <CloseButton
+          position="absolute"
+          right={1}
+          top={1}
+          onClick={handleCloseAlert}
+        />
+      </Alert>
+    </Box>
+  )
+}
+
+export default SelectionNotification

--- a/src/components/ThreeViewer/SelectionNotificationBuilding.jsx
+++ b/src/components/ThreeViewer/SelectionNotificationBuilding.jsx
@@ -1,0 +1,87 @@
+import {
+  Alert,
+  Box,
+  Button,
+  CloseButton,
+  useDisclosure,
+  Wrap,
+} from "@chakra-ui/react"
+import React, { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { simulationForNewBuilding } from "../../simulation/main"
+
+const SelectionNotificationBuilding = ({
+  selectedMesh,
+  setSelectedMesh,
+  simulationMeshes,
+  setSimulationMeshes,
+  geometries,
+  geoLocation,
+}) => {
+  const { isOpen, onClose, onOpen } = useDisclosure()
+  const [isLoading, setIsLoading] = useState(false)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    if (selectedMesh.length > 0) {
+      onOpen()
+    }
+  }, [selectedMesh])
+
+  const handleCloseAlert = () => {
+    onClose()
+    setSelectedMesh([])
+  }
+
+  if (!isOpen) return null
+
+  const handleResimulationClick = async () => {
+    setIsLoading(true)
+    try {
+      await simulationForNewBuilding({
+        selectedMesh,
+        setSelectedMesh,
+        simulationMeshes,
+        setSimulationMeshes,
+        geometries,
+        geoLocation,
+      })
+    } finally {
+      setIsLoading(false)
+      onClose()
+    }
+  }
+
+  return (
+    <Box
+      position="fixed"
+      bottom={4}
+      left="50%"
+      transform="translateX(-50%)"
+      width="300px"
+      zIndex={9999}
+    >
+      <Alert alignItems="start" boxShadow="md" rounded="md" colorScheme="gray">
+        <Box width="100%">
+          <Wrap spacing={2} justify="start">
+            <Button
+              isLoading={isLoading}
+              colorScheme="teal"
+              onClick={handleResimulationClick}
+            >
+              {t("button.simulateBuilding")}
+            </Button>
+          </Wrap>
+        </Box>
+        <CloseButton
+          position="absolute"
+          right={1}
+          top={1}
+          onClick={handleCloseAlert}
+        />
+      </Alert>
+    </Box>
+  )
+}
+
+export default SelectionNotificationBuilding

--- a/src/components/ThreeViewer/SelectionNotificationPV.jsx
+++ b/src/components/ThreeViewer/SelectionNotificationPV.jsx
@@ -7,7 +7,7 @@ import {
   useDisclosure,
   Wrap,
 } from "@chakra-ui/react"
-import React, { useEffect, useRef } from "react"
+import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import SavingCalculation from "../PVSimulation/SavingsCalculation"
 
@@ -23,7 +23,7 @@ const SelectionNotificationPV = ({
     if (selectedPVSystem.length > 0) {
       onOpen()
     }
-  }, [selectedPVSystem, onOpen])
+  }, [selectedPVSystem])
 
   const handleCloseAlert = () => {
     onClose()

--- a/src/components/ThreeViewer/SelectionNotificationPV.jsx
+++ b/src/components/ThreeViewer/SelectionNotificationPV.jsx
@@ -6,33 +6,26 @@ import {
   CloseButton,
   useDisclosure,
   Wrap,
-  WrapItem,
 } from "@chakra-ui/react"
 import React, { useEffect, useRef } from "react"
+import SavingCalculation from "../PVSimulation/SavingsCalculation"
 
-const SelectionNotification = ({ selection, setSelection, buttons }) => {
+const SelectionNotificationPV = ({
+  selectedPVSystem,
+  setSelectedPVSystem,
+  setPVSystems,
+}) => {
   const { isOpen, onClose, onOpen } = useDisclosure()
-  const hasShownAlertRef = useRef(false)
 
   useEffect(() => {
-    if (selection.length > 0 && !hasShownAlertRef.current) {
+    if (selectedPVSystem.length > 0) {
       onOpen()
-      hasShownAlertRef.current = true
     }
-  }, [selection, onOpen])
+  }, [selectedPVSystem, onOpen])
 
   const handleCloseAlert = () => {
     onClose()
-    setSelection([])
-    hasShownAlertRef.current = false
-  }
-
-  const handleButtonClick = (action) => {
-    // Call the button's action if provided
-    if (action) {
-      action()
-    }
-    handleCloseAlert()
+    setSelectedPVSystem([])
   }
 
   if (!isOpen) return null
@@ -49,19 +42,23 @@ const SelectionNotification = ({ selection, setSelection, buttons }) => {
       <Alert alignItems="start" boxShadow="md" rounded="md" colorScheme="teal">
         <Box width="100%">
           <AlertDescription display="block" mb={2}>
-            We've created your account for you.
+            {"Was soll mit dieser Anlage geschehen?"}
           </AlertDescription>
           <Wrap spacing={2} justify="start">
-            {buttons.map((button, index) => (
-              <WrapItem key={index}>
-                <Button
-                  size="sm"
-                  onClick={() => handleButtonClick(button.action)}
-                >
-                  {button.label}
-                </Button>
-              </WrapItem>
-            ))}
+            <SavingCalculation
+              selectedPVSystem={selectedPVSystem}
+              setSelectedPVSystem={setSelectedPVSystem}
+              onCloseAlert={onClose}
+            />
+            <Button
+              onClick={() => {
+                setPVSystems([])
+                setSelectedPVSystem([])
+                onClose()
+              }}
+            >
+              Anlage löschen
+            </Button>
           </Wrap>
         </Box>
         <CloseButton
@@ -75,4 +72,4 @@ const SelectionNotification = ({ selection, setSelection, buttons }) => {
   )
 }
 
-export default SelectionNotification
+export default SelectionNotificationPV

--- a/src/components/ThreeViewer/SelectionNotificationPV.jsx
+++ b/src/components/ThreeViewer/SelectionNotificationPV.jsx
@@ -8,6 +8,7 @@ import {
   Wrap,
 } from "@chakra-ui/react"
 import React, { useEffect, useRef } from "react"
+import { useTranslation } from "react-i18next"
 import SavingCalculation from "../PVSimulation/SavingsCalculation"
 
 const SelectionNotificationPV = ({
@@ -16,6 +17,7 @@ const SelectionNotificationPV = ({
   setPVSystems,
 }) => {
   const { isOpen, onClose, onOpen } = useDisclosure()
+  const { t } = useTranslation()
 
   useEffect(() => {
     if (selectedPVSystem.length > 0) {
@@ -42,7 +44,7 @@ const SelectionNotificationPV = ({
       <Alert alignItems="start" boxShadow="md" rounded="md" colorScheme="gray">
         <Box width="100%">
           <AlertDescription display="block" mb={2}>
-            {"Was soll mit dieser Anlage geschehen?"}
+            {t("savingsCalculation.notificationLabel")}
           </AlertDescription>
           <Wrap spacing={2} justify="start">
             <SavingCalculation
@@ -58,7 +60,7 @@ const SelectionNotificationPV = ({
                 onClose()
               }}
             >
-              Anlage löschen
+              {t("delete")}
             </Button>
           </Wrap>
         </Box>

--- a/src/components/ThreeViewer/SelectionNotificationPV.jsx
+++ b/src/components/ThreeViewer/SelectionNotificationPV.jsx
@@ -39,7 +39,7 @@ const SelectionNotificationPV = ({
       width="300px"
       zIndex={9999}
     >
-      <Alert alignItems="start" boxShadow="md" rounded="md" colorScheme="teal">
+      <Alert alignItems="start" boxShadow="md" rounded="md" colorScheme="gray">
         <Box width="100%">
           <AlertDescription display="block" mb={2}>
             {"Was soll mit dieser Anlage geschehen?"}
@@ -51,6 +51,7 @@ const SelectionNotificationPV = ({
               onCloseAlert={onClose}
             />
             <Button
+              colorScheme="teal"
               onClick={() => {
                 setPVSystems([])
                 setSelectedPVSystem([])

--- a/src/pages/Simulation.jsx
+++ b/src/pages/Simulation.jsx
@@ -36,7 +36,7 @@ function Index() {
   // highlighted meshes for resimulation
   const [selectedMesh, setSelectedMesh] = useState([])
   // highlighted PVSystems for deletion or calculation
-  const [selectedPVSystem, setselectedPVSystem] = useState([])
+  const [selectedPVSystem, setSelectedPVSystem] = useState([])
   // meshes that were simulated
   const [simulationMeshes, setSimulationMeshes] = useState([])
 
@@ -74,6 +74,8 @@ function Index() {
             geoLocation={location}
             setPVSystems={setPVSystems}
             pvSystems={pvSystems}
+            selectedPVSystem={selectedPVSystem}
+            setSelectedPVSystem={setSelectedPVSystem}
             pvPoints={pvPoints}
             setPVPoints={setPVPoints}
             simulationMeshes={simulationMeshes}
@@ -93,7 +95,7 @@ function Index() {
             selectedMesh={selectedMesh}
             setSelectedMesh={setSelectedMesh}
             selectedPVSystem={selectedPVSystem}
-            setselectedPVSystem={setselectedPVSystem}
+            setSelectedPVSystem={setSelectedPVSystem}
             pvPoints={pvPoints}
             setPVPoints={setPVPoints}
             vegetationGeometries={vegetationGeometries}

--- a/src/pages/Simulation.jsx
+++ b/src/pages/Simulation.jsx
@@ -35,6 +35,8 @@ function Index() {
   })
   // highlighted meshes for resimulation
   const [selectedMesh, setSelectedMesh] = useState([])
+  // highlighted PVSystems for deletion or calculation
+  const [selectedPVSystem, setselectedPVSystem] = useState([])
   // meshes that were simulated
   const [simulationMeshes, setSimulationMeshes] = useState([])
 
@@ -90,6 +92,8 @@ function Index() {
             setPVSystems={setPVSystems}
             selectedMesh={selectedMesh}
             setSelectedMesh={setSelectedMesh}
+            selectedPVSystem={selectedPVSystem}
+            setselectedPVSystem={setselectedPVSystem}
             pvPoints={pvPoints}
             setPVPoints={setPVPoints}
             vegetationGeometries={vegetationGeometries}


### PR DESCRIPTION
* Refactoring of the double click methods in `CustomMapControl`
* Adding a possibility to select PV systems
* Getting a notification window with relevant buttons for both selecting PV systems and selecting buildings

Also see #291 

Next steps (in a sperate PR):
* Extract the intersection methods from `CustomMapControl` and move it to a `ControlUtils` file
* Import these utils in the DrawPVControl
* Check if the intersected method is a simulated building. Only allow PVPoints on simulated buildings