### PR TITLE
Search popups for buildings only

### DIFF
--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -62,26 +62,20 @@ function Index() {
       })
     } else {
       // Use only the first one
-      locations = [locations[0]]
-      const lons = locations.map((loc) => loc.lon)
-      const lats = locations.map((loc) => loc.lat)
+      const location = locations[0]
+      let bounds = location.boundingBox
 
-      const bounds = [
-        Math.min(...lons),
-        Math.min(...lats),
-        Math.max(...lons),
-        Math.max(...lats),
-      ]
+      if (location.addressType === 'building') {
+        // Only add popup when search result is a building!
+        setMapMarkers([<MapPopup key={location.key} {...location} />])
+      }
+      console.log('bounds')
+      console.log(bounds)
       mapRef.current.fitBounds(bounds, {
         maxZoom: 17,
         speed: 2,
       })
     }
-    setMapMarkers(
-      locations.map((location) => (
-        <MapPopup key={location.key} {...location} />
-      )),
-    )
   }
 
   const mapRef = useRef()

--- a/src/simulation/location.js
+++ b/src/simulation/location.js
@@ -50,15 +50,14 @@ async function processAddress(searchString) {
 }
 
 function format_address(address) {
-  let addr =
-    (address.road || '') +
-    ' ' +
-    (address.house_number || '') +
-    ', ' +
-    (address.postcode || '') +
-    ' ' +
-    (address.city || '')
-  return addr
+  const part1 = (address.road || '') + ' ' + (address.house_number || '')
+  const part2 = (address.postcode || '') + ' ' + (address.city || '')
+
+  if (part1 != ' ' && part2 != ' ') {
+    return part1 + ', ' + part2
+  } else {
+    return part1 + part2
+  }
 }
 
 async function fetchCoordinates(url) {

--- a/src/simulation/location.js
+++ b/src/simulation/location.js
@@ -41,12 +41,18 @@ async function processAddress(searchString) {
       )
     response = await fetchCoordinates(url)
   }
-  return response.map((obj) => ({
-    lat: obj.lat,
-    lon: obj.lon,
-    key: obj.place_id,
-    display_name: format_address(obj.address),
-  }))
+  return response.map((obj) => {
+    console.log(obj.boundingbox)
+    let [lat0, lat1, lon0, lon1] = obj.boundingbox.map(parseFloat)
+    return {
+      lat: obj.lat,
+      lon: obj.lon,
+      key: obj.place_id,
+      addressType: obj.addresstype,
+      boundingBox: [lon0, lat0, lon1, lat1],
+      display_name: format_address(obj.address),
+    }
+  })
 }
 
 function format_address(address) {


### PR DESCRIPTION
This changes some small things in the search box behaviour to reduce possible confusion from the search results.

1. The map will always zoom to the bounding box of the search result (previously it would zoom in to zoom level 17, centering on the search result's midpoint, which can be confusing when the search result is not a building, but e.g. an entire city or road)
2. The "simulation" popup will only show if the search result is actually a building. It will no longer show weird random popups for larger objects such as ", Berlin"

This should fix issues such as the one error report we got via email.