### PR TITLE
Remove Legacy Feature: Entering Coordinates into Search Box

### DIFF
--- a/src/components/PVSimulation/SearchField.jsx
+++ b/src/components/PVSimulation/SearchField.jsx
@@ -1,7 +1,7 @@
 import { Button, Input, List, ListItem } from '@chakra-ui/react'
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { requestLocation } from '../../simulation/location'
+import { processAddress } from '../../simulation/location'
 
 export default function SearchField({ callback }) {
   const [inputValue, setInputValue] = useState('')
@@ -102,14 +102,14 @@ export default function SearchField({ callback }) {
 
   const handleSubmit = async (event) => {
     event.preventDefault()
-    const locations = await requestLocation(inputValue)
+    const locations = await processAddress(inputValue)
     console.warn(locations)
     callback(locations)
   }
 
   const handleSuggestionClick = (suggestion) => {
     setInputValue(suggestion)
-    requestLocation(suggestion).then((locations) => {
+    processAddress(suggestion).then((locations) => {
       console.warn(locations)
       callback(locations)
     })

--- a/src/simulation/location.js
+++ b/src/simulation/location.js
@@ -2,33 +2,7 @@
  */
 export var coordinatesXY15, coordinatesLonLat, coordinatesWebMercator
 
-export async function requestLocation(searchString) {
-  let options = extractLongitudeLatitude(searchString)
-  if (options.length == 0) {
-    options = processAddress(searchString)
-  }
-  return options
-}
-
-function extractLongitudeLatitude(searchString) {
-  if (/^[-]?(\d+(\.\d+)?),\s*[-]?(\d+(\.\d+)?)$/.test(searchString)) {
-    const [lat, lon] = searchString
-      .split(',')
-      .map((value) => parseFloat(value.trim()))
-    return [
-      {
-        lat,
-        lon,
-        display_name: `${lat},${lon}`,
-        key: 'coordinates',
-      },
-    ]
-  } else {
-    return []
-  }
-}
-
-async function processAddress(searchString) {
+export async function processAddress(searchString) {
   let url =
     'https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&q='
       .concat(searchString)


### PR DESCRIPTION
No longer allows entering Lat/Lon coordinates into the search box, as we have a map view now. The feature has been broken since 9e1d0611 anyways :)