### PR TITLE
Disable 3rf's default tone mapping

### DIFF
--- a/src/components/ThreeViewer/Meshes/SurroundingMesh.jsx
+++ b/src/components/ThreeViewer/Meshes/SurroundingMesh.jsx
@@ -7,7 +7,7 @@ const SurroundingMesh = ({ geometries }) => {
         <mesh key={index} geometry={geometry}>
           <meshLambertMaterial
             vertexColors={false}
-            color={0xab9980}
+            color={0xc4b69f}
             side={THREE.DoubleSide}
           />
         </mesh>

--- a/src/components/ThreeViewer/Scene.jsx
+++ b/src/components/ThreeViewer/Scene.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react'
 import { Canvas } from 'react-three-fiber'
+import * as THREE from 'three'
 
 import CustomMapControl from './Controls/CustomMapControl'
 import DrawPVControl from './Controls/DrawPVControl'
@@ -70,6 +71,7 @@ const Scene = ({
           up: [0, 0, 1],
           ref: cameraRef,
         }}
+        gl={{ antialias: true, toneMapping: THREE.NoToneMapping }}
       >
         <ambientLight intensity={2} />
         <directionalLight intensity={1} position={[0, -1, -2]} />


### PR DESCRIPTION
By default, `react-three-fiber` applies some tone mapping to the scene, causing our terrain map textures to look too bright and washed out. This PR fixes that by disabling the tone mapping.

## TODO:
* [ ] This also affects the visuals of the rendered buildings. Should we adjust the building / simulation colours? I'd consider making the non-simulation buildings (beige ones) a bit brighter/less saturated.

## Map view
![image](https://github.com/user-attachments/assets/37c13ccf-b860-4e29-9ac9-cb85fcc6369c)

## 3D view on `main`
![image](https://github.com/user-attachments/assets/1d8eb202-a6f4-4916-8550-7ad1db171cc2)

## 3D view after this PR
![image](https://github.com/user-attachments/assets/e33d71b7-1d05-4e7b-bff7-61c2a0b7a3dc)
