### PR TITLE
Finally fix map colors in 3D viewer

### DIFF
--- a/src/components/ThreeViewer/Terrain.jsx
+++ b/src/components/ThreeViewer/Terrain.jsx
@@ -76,8 +76,7 @@ const TerrainTile = (props) => {
       const map = await mapFuture
       map.colorSpace = THREE.SRGBColorSpace
       setMaterial(
-        new THREE.MeshLambertMaterial({
-          flatShading: false,
+        new THREE.MeshBasicMaterial({
           map: await mapFuture,
           side: THREE.FrontSide,
         }),


### PR DESCRIPTION
The Map tiles are still rendering wrong in the 3D view (e.g. the purple area is shown as white):
![Screenshot From 2025-02-21 08-37-13](https://github.com/user-attachments/assets/9e133002-2fae-4705-8310-0926fc873495)

![Screenshot From 2025-02-21 08-31-46](https://github.com/user-attachments/assets/48e64f17-8ad5-426b-a2df-5ac56dfd0810)

This PR finally fixes that:

![Screenshot From 2025-02-21 08-28-57](https://github.com/user-attachments/assets/320f8610-9f9d-4c00-8a4c-1fc7542d82dc)

